### PR TITLE
Remove warnings

### DIFF
--- a/kafo_wizards.gemspec
+++ b/kafo_wizards.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.5", "< 3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'thor'
   spec.add_development_dependency "minitest", "~> 4.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "mocha"

--- a/lib/kafo_wizards/entries/abstract.rb
+++ b/lib/kafo_wizards/entries/abstract.rb
@@ -18,9 +18,9 @@ module KafoWizards::Entries
     def display_type(with_ancestry=false)
       classes = self.class.ancestors.select { |cls| cls.name =~ /Entry\Z/ }
       if with_ancestry
-        result = classes.map { |cls| class_to_underscore(cls.name) }
+        classes.map { |cls| class_to_underscore(cls.name) }
       else
-        result = class_to_underscore(classes.first.name)
+        class_to_underscore(classes.first.name)
       end
     end
 

--- a/lib/kafo_wizards/highline/string_or_file_renderer.rb
+++ b/lib/kafo_wizards/highline/string_or_file_renderer.rb
@@ -13,7 +13,7 @@ module KafoWizards
       def render_action(entry)
         say entry.description if entry.description
         key = ask("file path or key")
-        key = File.read(key) if File.exists?(key)
+        key = File.read(key) if File.exist?(key)
         entry.update(key.chomp)
         nil
       end

--- a/test/kafo_wizards/highline/password_renderer_test.rb
+++ b/test/kafo_wizards/highline/password_renderer_test.rb
@@ -11,7 +11,7 @@ describe KafoWizards::HighLine::PasswordRenderer do
 
   describe 'render value' do
     it "should print stars instead of the password" do
-      renderer.render_value(entry).must_match /\*{10}/
+      renderer.render_value(entry).must_match(/\*{10}/)
     end
   end
 
@@ -39,8 +39,8 @@ describe KafoWizards::HighLine::PasswordRenderer do
       e.stubs(:update).returns('xxx')
       renderer.render_action(e)
       out = highline_output
-      out.must_match /Enter new password: \*{8}/
-      out.wont_match /PASSWORD/
+      out.must_match(/Enter new password: \*{8}/)
+      out.wont_match(/PASSWORD/)
     end
   end
 
@@ -71,9 +71,9 @@ describe KafoWizards::HighLine::PasswordRenderer do
       e.stubs(:update).returns('xxx')
       renderer.render_action(e)
       out = highline_output
-      out.must_match /Enter new password: \*{8}/
-      out.must_match /Re-type new password: \*{8}/
-      out.wont_match /PASSWORD/
+      out.must_match(/Enter new password: \*{8}/)
+      out.must_match(/Re-type new password: \*{8}/)
+      out.wont_match(/PASSWORD/)
     end
   end
 

--- a/test/kafo_wizards/highline/selector_renderer_test.rb
+++ b/test/kafo_wizards/highline/selector_renderer_test.rb
@@ -41,9 +41,9 @@ describe KafoWizards::HighLine::SelectorRenderer do
       entry.stubs(:update).returns('xxx')
       renderer.render_action(entry)
       out = highline_output
-      out.must_match /Select Name: /
-      out.must_match /1. Tom/
-      out.must_match /2. Jerry/
+      out.must_match(/Select Name: /)
+      out.must_match(/1. Tom/)
+      out.must_match(/2. Jerry/)
     end
 
     it 'should return nil' do

--- a/test/kafo_wizards/highline/string_or_file_renderer_test.rb
+++ b/test/kafo_wizards/highline/string_or_file_renderer_test.rb
@@ -12,11 +12,11 @@ describe KafoWizards::HighLine::StringOrFileRenderer do
 
   describe 'render value' do
     it "prints text shortened on one line" do
-      renderer.render_value(entry).must_match /\.\.\./
+      renderer.render_value(entry).must_match(/\.\.\./)
     end
 
     it 'prints lenght' do
-      renderer.render_value(entry).must_match /(70 bytes)/
+      renderer.render_value(entry).must_match(/(70 bytes)/)
     end
 
     it 'prints empty string for nil' do

--- a/test/kafo_wizards/highline/string_renderer_test.rb
+++ b/test/kafo_wizards/highline/string_renderer_test.rb
@@ -43,12 +43,12 @@ describe KafoWizards::HighLine::StringRenderer do
 
     it 'asks for a new value' do
       renderer.render_action(entry)
-      highline_output.must_match /New value for Name:/
+      highline_output.must_match(/New value for Name:/)
     end
 
     it 'prints the entry description' do
       renderer.render_action(entry)
-      highline_output.must_match /Descr/
+      highline_output.must_match(/Descr/)
     end
   end
 end

--- a/test/kafo_wizards/highline/wizard_test.rb
+++ b/test/kafo_wizards/highline/wizard_test.rb
@@ -34,30 +34,30 @@ describe KafoWizards::HighLine::Wizard do
     end
 
     it 'prints header' do
-      wizard_output.must_match /Header/
+      wizard_output.must_match(/Header/)
     end
 
     it 'prints current values' do
-      wizard_output.must_match /Name: 'Any'/
+      wizard_output.must_match(/Name: 'Any'/)
     end
 
     it 'prints description' do
-      wizard_output.must_match /Description/
+      wizard_output.must_match(/Description/)
     end
 
     it 'prints choices' do
       out = wizard_output
-      out.must_match /Ok/
-      out.must_match /Change Name/
-      out.must_match /Cancel/
+      out.must_match(/Ok/)
+      out.must_match(/Change Name/)
+      out.must_match(/Cancel/)
     end
 
     it "prints the default button first" do
-      wizard_output.must_match /1\. Ok/
+      wizard_output.must_match(/1\. Ok/)
     end
 
     it "prints the remaining buttons at the end" do
-      wizard_output.must_match /3\. Cancel/
+      wizard_output.must_match(/3\. Cancel/)
     end
 
     it "returns button pressed" do
@@ -117,7 +117,7 @@ describe KafoWizards::HighLine::Wizard do
       input.rewind
       wizard.entries = [ok, cancel, factory.string(:name, :required => true)]
       wizard.execute_menu.must_equal :cancel
-      highline_output.must_match /Name must be present/
+      highline_output.must_match(/Name must be present/)
     end
 
     it "triggers hooks" do
@@ -138,15 +138,15 @@ describe KafoWizards::HighLine::Wizard do
       wizard.print_values
       out = highline_output
 
-      out.must_match /Name: 'Any'/
-      out.must_match /Age: ''/
-      out.wont_match /Ok/
+      out.must_match(/Name: 'Any'/)
+      out.must_match(/Age: ''/)
+      out.wont_match(/Ok/)
     end
 
     it 'prints required values with asterisk' do
       wizard.entries = [ok, name, factory.string(:age, :required => true)]
       wizard.print_values
-      highline_output.must_match /\*Age/
+      highline_output.must_match(/\*Age/)
 
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ end
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/mock'
-require "mocha/setup"
+require "mocha/minitest"
 
 require 'kafo_wizards'
 


### PR DESCRIPTION
Still contains a warning from simplecov and some warnings on Ruby 2.7 when using HighLine 1.x. For the latter there's https://github.com/theforeman/kafo_wizards/pull/3.